### PR TITLE
Simplify with default parsers and abstracted logging

### DIFF
--- a/kellerld.meta
+++ b/kellerld.meta
@@ -1,55 +1,52 @@
 {
   "0": {
-    "type": "error",
+    "llType": "error",
     "columns": [
       {
-        "name": "error code",
+        "llabel": "error code",
         "color": "red",
         "marker": "o",
         "dtype": "int"
       },
       {
-        "name": "error message",
+        "llabel": "error message",
         "dtype": "str"
       }
     ]
   },
   "1": {
-    "type": "rom",
+    "llType": "data",
     "columns": [
-        {
-            "name": "month",
-            "dtype": "int"
-        },
-        {
-            "name": "day",
-            "dtype": "int"
-        },
-        {
-            "name": "year",
-            "dtype": "int"
-        },
-        {
-            "name": "pMin",
-            "units": "bar",
-            "dtype": "float"
-        },
-        {
-            "name": "pMax",
-            "units": "bar",
-            "dtype": "float"
-        },
-        {
-            "name": "pModeID",
-            "dtype": "int"
-        }
+      {
+        "llabel": "pressure",
+        "units": "mbar",
+        "dtype": "float",
+        "color": "red",
+        "marker": "o"
+      },
+      {
+        "llabel": "temperature",
+        "units": "C",
+        "dtype": "float",
+        "color": "green",
+        "marker": "x",
+        "scalar": 2.0
+      },
+      {
+        "llabel": "pressure_raw",
+        "dtype": "int"
+      },
+      {
+        "llabel": "temperature_raw",
+        "dtype": "int"
+      }
     ]
   },
   "2": {
-    "type": "configuration",
+    "llType": "config",
     "columns": [
       {
-        "name": "ctrl register",
+        "llabel": "ctrl register",
         "units": "bitmap",
         "bits": {
           "0": {
@@ -64,7 +61,7 @@
         "marker": "o"
       },
       {
-        "name": "cfg register",
+        "llabel": "cfg register",
         "units": "bitmap",
         "bits": {
           "0": {
@@ -80,35 +77,35 @@
       }
     ]
   },
-  "3": {
-    "type": "calibration"
-  },
-  "4": {
-    "type": "data",
+  "5": {
+    "llType": "rom",
     "columns": [
-      {
-        "name": "pressure",
-        "units": "mbar",
-        "dtype": "float",
-        "color": "red",
-        "marker": "o"
-      },
-      {
-        "name": "temperature",
-        "units": "C",
-        "dtype": "float",
-        "color": "green",
-        "marker": "x",
-        "scalar": 2.0
-      },
-      {
-        "name": "pressure_raw",
-        "dtype": "int"
-      },
-      {
-        "name": "temperature_raw",
-        "dtype": "int"
-      }
+        {
+            "llabel": "month",
+            "dtype": "int"
+        },
+        {
+            "llabel": "day",
+            "dtype": "int"
+        },
+        {
+            "llabel": "year",
+            "dtype": "int"
+        },
+        {
+            "llabel": "pMin",
+            "units": "bar",
+            "dtype": "float"
+        },
+        {
+            "llabel": "pMax",
+            "units": "bar",
+            "dtype": "float"
+        },
+        {
+            "llabel": "pModeID",
+            "dtype": "int"
+        }
     ]
   }
 }

--- a/test-kellerld.py
+++ b/test-kellerld.py
@@ -1,32 +1,20 @@
 #!/usr/bin/python3
 
-import argparse
 from kellerLD import KellerLD
-from pathlib import Path
-import llog
-import time
+from llog import LLogWriter
 
 device = "kellerld"
-defaultMeta = Path(__file__).resolve().parent / f"{device}.meta"
-
-parser = argparse.ArgumentParser(description=f'{device} test')
-parser.add_argument('--output', action='store', type=str, default=None)
-parser.add_argument('--meta', action='store', type=str, default=defaultMeta)
-parser.add_argument('--frequency', action='store', type=int, default=5,
-                    help="set the measurement frequency")
+parser = LLogWriter.create_default_parser(__file__, device, default_frequency=5)
 args = parser.parse_args()
 
 
 with llog.LLogWriter(args.meta, args.output) as log:
     keller = KellerLD(args.bus)
     keller.init()
-    log.log(llog.LLOG_ROM, f'{keller.month} {keller.day} {keller.year} {keller.pMin} {keller.pMax} {keller.pModeID}')
-
-    while True:
-        try:
-            keller.read()
-            log.log(llog.LLOG_DATA, f'{keller.pressure():.6f} {keller.temperature():.2f}')
-        except Exception as e:
-            log.log(llog.LLOG_ERROR, e)
-        if args.frequency:
-            time.sleep(1.0/args.frequency)
+    log.log_rom(f'{keller.month} {keller.day} {keller.year} {keller.pMin} {keller.pMax} {keller.pModeID}')
+    
+    def data_getter():
+      keller.read()
+      return f'{keller.pressure():.6f} {keller.temperature():.2f}'
+    
+    log.log_data_loop(data_getter, parser_args=args)


### PR DESCRIPTION
- basically just copied [`test-bmp280.py`](https://github.com/ES-Alexander/bmp280-python/blob/simplify/bmp280/test-bmp280.py) for the report format, since they're both pressure+temp sensors and seemed to already be plotting pretty much the same things
- had to update the metadata file because it included an empty "calibration" field, had different ids to the llog ones, and used "type" and "name" instead of "llType" and "llabel"
- left the "color", "marker", "bits", and "scalar" fields, because I'm not sure if you want them kept or removed, and I figure they'll be ignored if they're not used anyway
- relevant to https://github.com/bluerobotics/navigator-validation/issues/6
- NOT tested