### PR TITLE
Fix mode designation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Get the most recent pressure measurement.
 
 Returns the most recent pressure in bar. Call read() to update.
 
+#### set_reference_pressure(pBar)
+
+Update the reference pressure value for PR Mode (Vented Gauge) sensors, in bar.
+
+```py
+    local_atmosphere = 1.01325  # ideally read regularly from an air pressure sensor
+    sensor.set_reference_pressure(local_atmosphere)
+```
+
 ### temperature()
 
 Get the most recent temperature measurement.

--- a/kellerLD.py
+++ b/kellerLD.py
@@ -47,8 +47,7 @@ class KellerLD(object):
 		
 		pModeID = scaling0 & 0b11
 		self.pMode = self._P_MODES[pModeID]
-		self.pModeOffset = self._P_MODE_OFFSETS[pModeID]
-		self.debug(("pMode", self.pMode, "pressure offset [bar]", self.pModeOffset))
+		self.set_reference_pressure(self._P_MODE_OFFSETS[pModeID])
 		
 		self.year = scaling0 >> 11
 		self.month = (scaling0 & 0b0000011110000000) >> 7
@@ -101,6 +100,17 @@ class KellerLD(object):
 		self.debug(("pMin:", self.pMin, "pMax:", self.pMax))
 
 		return True
+
+	def set_reference_pressure(self, pBar):
+		""" Set the reference pressure for the sensor.
+		
+		Vented Gauge sensors are relative to the pressure on the rear/inside of the sensor
+		element, so are more accurate if that reference value is kept updated from an aerial
+		pressure sensor (e.g. inside an enclosure, or to the local atmospheric pressure if
+		the sensor is installed in the wall of a water tank).
+		"""
+		self.pModeOffset = pBar
+		self.debug(("pMode", self.pMode, "pressure offset [bar]", self.pModeOffset))
 
 	def read(self):
 		if self._bus is None:

--- a/kellerLD.py
+++ b/kellerLD.py
@@ -9,8 +9,8 @@ class KellerLD(object):
 	_REQUEST_MEASUREMENT = 0xAC
 	_DEBUG = False
 	_P_MODES = (
-		"PA Mode, Vented Gauge",   # Zero at atmospheric pressure
-		"PR Mode, Sealed Gauge",   # Zero at 1.0 bar
+		"PR Mode, Vented Gauge",   # Zero when front pressure == rear pressure
+		"PA Mode, Sealed Gauge",   # Zero at 1.0 bar
 		"PAA Mode, Absolute Gauge" # Zero at vacuum
 	)
 	_P_MODE_OFFSETS = (1.01325, 1.0, 0.0)


### PR DESCRIPTION
- Correct [swapped names of PR and PA mode sensors](https://www.keller-druck2.ch/swupdate/InstallerD-LineAddressManager/manual/Communication_Protocol_4LD-9LD_en.pdf#page=12)
- Allow updating [the reference pressure for vented gauge (PR mode) sensors](https://github.com/ArduPilot/ardupilot/issues/18968)
    - The Blue Robotics Bar100 is PA Mode, so this functionality is not critical for our use-cases, but could still be useful for others