### PR TITLE
kellerLD: reject measurements with invalid status-byte framing bits

### DIFF
--- a/example.py
+++ b/example.py
@@ -13,8 +13,8 @@ time.sleep(3)
 
 while True:
 	try:
-		sensor.read()
-		print("pressure: %7.4f bar\ttemperature: %0.2f C" % (sensor.pressure(), sensor.temperature()))
+		if sensor.read():
+			print(f"pressure: {sensor.pressure():7.4f} bar\ttemperature: {sensor.temperature():0.2f} C")
 		time.sleep(0.2)
 	except Exception as e:
 		print(e)

--- a/kellerLD.py
+++ b/kellerLD.py
@@ -141,6 +141,15 @@ class KellerLD(object):
 			return
 		'''
 
+		# Validate the vendor-reserved framing bits before trusting the data.
+		# A valid status byte is 0b01BMoEXX, so bit 7 must be 0 and bit 6 must
+		# be 1. Anything else means the sensor is not returning a normal
+		# measurement (e.g. 0x00 post-reset/not-ready, or 0xFF bus-stuck-high),
+		# and the accompanying pressure/temperature bytes must not be trusted.
+		if ((statusByte & 0b11 << 6) >> 6) != 0b01 :
+			print(f"Invalid status byte: 0x{statusByte:02X}")
+			return False
+
 		if statusByte & 0b11 << 3 :
 			print("Invalid mode: %d, expected 0!") % ((statusByte & 0b11 << 3) >> 3)
 			return False
@@ -194,8 +203,8 @@ if __name__ == '__main__':
 
 	while True:
 		try:
-			sensor.read()
-			print("pressure: %7.4f bar\ttemperature: %0.2f C") % (sensor.pressure(), sensor.temperature())
+			if sensor.read():
+				print(f"pressure: {sensor.pressure():7.4f} bar\ttemperature: {sensor.temperature():0.2f} C")
 			time.sleep(0.001)
 		except Exception as e:
 			print(e)


### PR DESCRIPTION
The 5-byte measurement read begins with a status byte (`0b01BMoEXX`). `read()` already rejects bad operating-mode bits (4–3) and the memory-checksum bit (2), but it never validates the two vendor-reserved framing bits: bit 7 must be 0 and bit 6 must be 1 in any valid measurement.

This lets through frames where those bits are wrong — most notably an all-zeros `0x00` status (sensor post-reset / not yet in a measurement state), which currently passes both existing checks and gets converted into a bogus pressure/temperature reading. There is no `pressureRaw == 0` fallback in this driver, so nothing else catches it.

This adds a single check, `(statusByte & 0b11000000) != 0b01000000`, rejecting any frame whose reserved bits aren't `01`. It brings the reference driver to full parity with the equivalent fix merged into ArduPilot's Keller driver ([ArduPilot/ardupilot#32889](https://github.com/ArduPilot/ardupilot/pull/32889)), which combines the mode, memory, and reserved-bit checks into one mask. The BUSY bit (5) is intentionally left unchecked, consistent with the existing `# Always busy for some reason` note.

Made with [Cursor](https://cursor.com)